### PR TITLE
Add browser-based resume to LaTeX converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
-- 👋 Hi, I’m @SaiKumaarr
-- 👀 I’m interested in Product Management and Business Analysis
+# Resume Format Converter
 
+This repository contains a lightweight web application that converts resumes
+written in a custom plain-text structure into a LaTeX document and a ready to
+download PDF. Up to five resumes can be processed in a single batch.
 
-<!--
+## Features
+
+- Upload between one and five files at a time
+- Parse the custom resume layout into structured data
+- Generate LaTeX source code from the parsed resume
+- Produce a PDF summary using [jsPDF](https://github.com/parallax/jsPDF)
+- Offer download buttons for both the `.tex` and `.pdf` files
+- Provide a sample resume template for quick getting started
+
+## Getting started
+
+1. Open `public/index.html` in your browser. No build step is necessary.
+2. Click **Download sample format** to grab the example `.txt` file and update it
+   with your information, or write your own file following the same structure.
+3. Use the upload area to select up to five resume files. Each file is processed
+   instantly in your browser.
+4. For every resume a LaTeX preview is displayed. Use the buttons to download the
+   `.tex` source or the generated PDF snapshot.
+
+## Custom resume format
+
+The converter expects resumes to follow a straightforward plain-text structure:
+
+```
+Name: Ada Lovelace
+Email: ada@example.com
+Phone: +44 0000 0000
+Summary:
+- Mathematician and writer with a passion for computation.
+Experience:
+* Analytical Engines Ltd | Consultant | 1843-1845
+Education:
+* University of London | Mathematics | 1835
+Skills:
+- Analytical Thinking
+- Programming Languages: Sketching Engines
+```
+
+Headings end with a colon, and list items begin with `-` or `*`. The Experience
+and Education sections accept pipe-separated details in the order
+`Organisation | Role | Duration`.
+
+## Notes
+
+- All processing happens client-side. The resumes you upload never leave your
+  browser.
+- The generated LaTeX document uses a compact article layout for easy editing in
+  any TeX editor.
+- The PDF snapshot is produced by jsPDF and aims to offer a quick visual export.
+  If you need a fully typeset LaTeX PDF you can compile the downloaded `.tex`
+  file using your preferred LaTeX toolchain.

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,0 +1,215 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.6;
+  font-weight: 400;
+  --bg: #f5f5f7;
+  --card-bg: #ffffff;
+  --accent: #3f51b5;
+  --accent-dark: #2c3a8c;
+  --text: #1b1f24;
+  --muted: #586069;
+  --border: #d0d7de;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #273469, #4a6ee0);
+  color: #ffffff;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.app-header p {
+  margin: 0 auto;
+  max-width: 640px;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.upload-panel,
+.results-panel,
+.format-panel {
+  background: var(--card-bg);
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(31, 35, 40, 0.1);
+  padding: 1.5rem;
+  border: 1px solid rgba(12, 22, 34, 0.08);
+}
+
+.upload-panel h2,
+.results-panel h2,
+.format-panel h2 {
+  margin-top: 0;
+}
+
+.file-drop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--border);
+  border-radius: 0.75rem;
+  padding: 2rem 1.5rem;
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+  text-align: center;
+}
+
+.file-drop:hover,
+.file-drop:focus-within {
+  border-color: var(--accent);
+  background-color: rgba(63, 81, 181, 0.05);
+}
+
+.file-drop--dragging {
+  border-color: var(--accent);
+  background-color: rgba(63, 81, 181, 0.08);
+}
+
+.file-drop input[type='file'] {
+  display: none;
+}
+
+.file-drop__prompt {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.help-text {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.primary-button,
+.ghost-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.primary-button:hover,
+.primary-button:focus {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.ghost-button:hover,
+.ghost-button:focus {
+  background: rgba(63, 81, 181, 0.08);
+  transform: translateY(-1px);
+}
+
+#upload-feedback {
+  min-height: 1.4rem;
+  margin-top: 0.75rem;
+  font-weight: 500;
+}
+
+#results {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.result-card {
+  border: 1px solid rgba(12, 22, 34, 0.08);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.result-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.result-card__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.result-card__status {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.result-card__body h4 {
+  margin: 0 0 0.5rem;
+}
+
+.latex-output {
+  width: 100%;
+  min-height: 200px;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.85rem;
+  resize: vertical;
+  background: rgba(246, 248, 250, 0.8);
+}
+
+.result-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.format-example {
+  background: rgba(31, 35, 40, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    grid-template-columns: 1fr;
+    padding: 1.5rem;
+  }
+
+  .result-card__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1,0 +1,316 @@
+const fileInput = document.getElementById('resume-files');
+const resultsContainer = document.getElementById('results');
+const feedback = document.getElementById('upload-feedback');
+const downloadSampleButton = document.getElementById('download-sample');
+const resultTemplate = document.getElementById('result-template');
+
+const SAMPLE_CONTENT = `Name: Ada Lovelace\nEmail: ada@example.com\nPhone: +44 0000 0000\nSummary:\n- Mathematician and writer with a passion for computation.\nExperience:\n* Analytical Engines Ltd | Consultant | 1843-1845\nEducation:\n* University of London | Mathematics | 1835\nSkills:\n- Analytical Thinking\n- Programming Languages: Sketching Engines\n`;
+
+const SECTION_KEYS = {
+  Summary: 'summary',
+  Experience: 'experience',
+  Education: 'education',
+  Skills: 'skills',
+  Projects: 'projects',
+  Certifications: 'certifications',
+};
+
+function escapeLatex(value = '') {
+  return value
+    .replace(/\\/g, '\\textbackslash ')
+    .replace(/([#%&$~_{}^])/g, '\\$1')
+    .replace(/\u2013|\u2014/g, '--');
+}
+
+function parseResume(text) {
+  const resume = {
+    name: '',
+    email: '',
+    phone: '',
+    summary: [],
+    experience: [],
+    education: [],
+    skills: [],
+    projects: [],
+    certifications: [],
+  };
+
+  const lines = text.split(/\r?\n/);
+  let currentSection = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const keyMatch = line.match(/^(\w[\w\s]+?):\s*(.*)$/);
+    if (keyMatch && SECTION_KEYS[keyMatch[1]]) {
+      currentSection = SECTION_KEYS[keyMatch[1]];
+      if (keyMatch[2]) {
+        resume[currentSection].push(keyMatch[2]);
+      }
+      continue;
+    }
+
+    switch (true) {
+      case /^Name:\s*/i.test(line):
+        resume.name = line.replace(/^Name:\s*/i, '');
+        break;
+      case /^Email:\s*/i.test(line):
+        resume.email = line.replace(/^Email:\s*/i, '');
+        break;
+      case /^Phone:\s*/i.test(line):
+        resume.phone = line.replace(/^Phone:\s*/i, '');
+        break;
+      case /^[*-]\s+/.test(line):
+        if (currentSection) {
+          resume[currentSection].push(line.replace(/^[*-]\s+/, ''));
+        }
+        break;
+      default:
+        if (currentSection) {
+          resume[currentSection].push(line);
+        }
+    }
+  }
+
+  return resume;
+}
+
+function buildLatex(resume) {
+  const lines = [];
+  lines.push('\\documentclass[11pt]{article}');
+  lines.push('\\usepackage[margin=1in]{geometry}');
+  lines.push('\\usepackage{enumitem}');
+  lines.push('\\usepackage{hyperref}');
+  lines.push('\\begin{document}');
+  lines.push(`\\begin{center}`);
+  lines.push(`  {\\LARGE ${escapeLatex(resume.name)} \\}`);
+  lines.push(`  \\vspace{0.25cm}`);
+  const contactParts = [resume.email && `\\href{mailto:${resume.email}}{${escapeLatex(resume.email)}}`, resume.phone && escapeLatex(resume.phone)]
+    .filter(Boolean)
+    .join(' $\mid$ ');
+  if (contactParts) {
+    lines.push(`  ${contactParts}`);
+  }
+  lines.push('\\end{center}');
+  lines.push('\\vspace{0.5cm}');
+
+  function renderBulletSection(title, items) {
+    if (!items.length) return;
+    lines.push(`\\section*{${title}}`);
+    lines.push('\\begin{itemize}[leftmargin=*]');
+    items.forEach((item) => lines.push(`  \\item ${escapeLatex(item)}`));
+    lines.push('\\end{itemize}');
+  }
+
+  function renderExperienceSection(items) {
+    if (!items.length) return;
+    lines.push('\\section*{Experience}');
+    items.forEach((item) => {
+      const parts = item.split('|').map((part) => escapeLatex(part.trim()));
+      const [company = '', role = '', dates = ''] = parts;
+      lines.push('\\begin{tabular*}{\\textwidth}{l@{\\extracolsep{\\fill}}r}');
+      lines.push(`  \\textbf{${company}} & ${dates} \\`);
+      if (role) {
+        lines.push(`  ${role} \\`);
+      }
+      lines.push('\\end{tabular*}');
+      lines.push('\\vspace{0.2cm}');
+    });
+  }
+
+  function renderEducationSection(items) {
+    if (!items.length) return;
+    lines.push('\\section*{Education}');
+    items.forEach((item) => {
+      const parts = item.split('|').map((part) => escapeLatex(part.trim()));
+      const [institution = '', degree = '', year = ''] = parts;
+      lines.push('\\begin{tabular*}{\\textwidth}{l@{\\extracolsep{\\fill}}r}');
+      lines.push(`  \\textbf{${institution}} & ${year} \\`);
+      if (degree) {
+        lines.push(`  ${degree} \\`);
+      }
+      lines.push('\\end{tabular*}');
+      lines.push('\\vspace{0.2cm}');
+    });
+  }
+
+  renderBulletSection('Summary', resume.summary);
+  renderExperienceSection(resume.experience);
+  renderEducationSection(resume.education);
+  renderBulletSection('Skills', resume.skills);
+  renderBulletSection('Projects', resume.projects);
+  renderBulletSection('Certifications', resume.certifications);
+
+  lines.push('\\end{document}');
+  return lines.join('\n');
+}
+
+function createPdf(resume) {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF({ unit: 'pt', format: 'letter' });
+  const margin = 54;
+  const lineHeight = 16;
+  let cursorY = margin;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(18);
+  doc.text(resume.name || 'Unnamed Candidate', margin, cursorY);
+  cursorY += lineHeight;
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(11);
+  const contact = [resume.email, resume.phone].filter(Boolean).join(' | ');
+  if (contact) {
+    doc.text(contact, margin, cursorY);
+    cursorY += lineHeight;
+  }
+
+  const sections = [
+    ['Summary', resume.summary],
+    ['Experience', resume.experience],
+    ['Education', resume.education],
+    ['Skills', resume.skills],
+    ['Projects', resume.projects],
+    ['Certifications', resume.certifications],
+  ];
+
+  sections.forEach(([title, items]) => {
+    if (!items.length) return;
+    cursorY += lineHeight;
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(13);
+    doc.text(title, margin, cursorY);
+    cursorY += 10;
+
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(11);
+
+    items.forEach((item) => {
+      const text = item.replace(/\s+/g, ' ');
+      const lines = doc.splitTextToSize(text, doc.internal.pageSize.getWidth() - margin * 2);
+      lines.forEach((line) => {
+        if (cursorY + lineHeight > doc.internal.pageSize.getHeight() - margin) {
+          doc.addPage();
+          cursorY = margin;
+        }
+        doc.text(line, margin, cursorY);
+        cursorY += lineHeight;
+      });
+    });
+  });
+
+  const pdfName = `${sanitizeFileName(resume.name || 'resume')}.pdf`;
+  doc.save(pdfName);
+}
+
+function sanitizeFileName(name) {
+  return name.replace(/[^a-z0-9\-]+/gi, '_').toLowerCase();
+}
+
+function downloadLatex(name, latexSource) {
+  const blob = new Blob([latexSource], { type: 'application/x-tex' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${sanitizeFileName(name || 'resume')}.tex`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+async function handleFiles(files) {
+  if (!files.length) {
+    feedback.textContent = 'No files selected.';
+    return;
+  }
+
+  if (files.length > 5) {
+    feedback.textContent = 'Please upload no more than five resumes at a time.';
+    return;
+  }
+
+  resultsContainer.innerHTML = '';
+  feedback.textContent = 'Processing resumes…';
+
+  const readPromises = Array.from(files).map((file) =>
+    file.text().then((content) => ({ file, content })).catch((error) => ({ file, error }))
+  );
+
+  const parsed = await Promise.all(readPromises);
+  let successCount = 0;
+
+  parsed.forEach(({ file, content, error }) => {
+    const card = resultTemplate.content.firstElementChild.cloneNode(true);
+    const title = card.querySelector('h3');
+    const status = card.querySelector('.result-card__status');
+    const latexOutput = card.querySelector('.latex-output');
+    const texButton = card.querySelector('.download-tex');
+    const pdfButton = card.querySelector('.download-pdf');
+
+    title.textContent = file.name;
+
+    if (error) {
+      status.textContent = 'Failed to read file';
+      latexOutput.value = error.message;
+      texButton.disabled = true;
+      pdfButton.disabled = true;
+      resultsContainer.appendChild(card);
+      return;
+    }
+
+    const resume = parseResume(content);
+    const latex = buildLatex(resume);
+    latexOutput.value = latex;
+    status.textContent = 'Ready to download';
+
+    texButton.addEventListener('click', () => downloadLatex(resume.name || file.name, latex));
+    pdfButton.addEventListener('click', () => createPdf(resume));
+
+    resultsContainer.appendChild(card);
+    successCount += 1;
+  });
+
+  feedback.textContent = `Converted ${successCount} of ${parsed.length} resume(s).`;
+}
+
+fileInput.addEventListener('change', (event) => {
+  handleFiles(event.target.files);
+});
+
+downloadSampleButton.addEventListener('click', () => {
+  const blob = new Blob([SAMPLE_CONTENT], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'resume-sample.txt';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+});
+
+// Allow dropping files on the label area for convenience.
+const fileDrop = document.querySelector('.file-drop');
+
+fileDrop.addEventListener('dragover', (event) => {
+  event.preventDefault();
+  fileDrop.classList.add('file-drop--dragging');
+});
+
+fileDrop.addEventListener('dragleave', () => {
+  fileDrop.classList.remove('file-drop--dragging');
+});
+
+fileDrop.addEventListener('drop', (event) => {
+  event.preventDefault();
+  fileDrop.classList.remove('file-drop--dragging');
+  if (event.dataTransfer?.files) {
+    const incomingFiles = Array.from(event.dataTransfer.files).slice(0, 5);
+    const transfer = new DataTransfer();
+    incomingFiles.forEach((file) => transfer.items.add(file));
+    fileInput.files = transfer.files;
+    handleFiles(transfer.files);
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resume Converter</title>
+    <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Resume Format Converter</h1>
+      <p>
+        Upload up to five resumes written in the custom plain-text format and
+        instantly generate LaTeX sources and downloadable PDFs.
+      </p>
+    </header>
+
+    <main class="app-main">
+      <section class="upload-panel" aria-label="Resume upload">
+        <h2>Upload your resumes</h2>
+        <p>
+          Each file must follow the custom structure described below. Select up
+          to five files at a time.
+        </p>
+        <label class="file-drop" for="resume-files">
+          <input
+            id="resume-files"
+            type="file"
+            accept=".txt,.resume"
+            multiple
+            aria-describedby="upload-help"
+          />
+          <span class="file-drop__prompt">Drop files here or click to browse</span>
+        </label>
+        <p id="upload-help" class="help-text">
+          Need an example? Download the sample template below and fill it with
+          your information.
+        </p>
+        <button id="download-sample" class="ghost-button" type="button">
+          Download sample format
+        </button>
+        <p id="upload-feedback" role="status" aria-live="polite"></p>
+      </section>
+
+      <section class="results-panel" aria-label="Conversion results">
+        <h2>Converted resumes</h2>
+        <p class="help-text">
+          After conversion the LaTeX source is shown for each resume. Use the
+          buttons to download the <code>.tex</code> file or the generated PDF.
+        </p>
+        <div id="results"></div>
+      </section>
+
+      <section class="format-panel" aria-label="Input format reference">
+        <h2>Custom resume format</h2>
+        <p>
+          The converter expects plain text files that follow the structure below.
+          Lines beginning with <code>-</code> or <code>*</code> are treated as
+          list items. Empty lines are ignored.
+        </p>
+        <pre class="format-example" aria-label="Sample resume format">
+Name: Ada Lovelace
+Email: ada@example.com
+Phone: +44 0000 0000
+Summary:
+- Mathematician and writer with a passion for computation.
+Experience:
+* Analytical Engines Ltd | Consultant | 1843-1845
+Education:
+* University of London | Mathematics | 1835
+Skills:
+- Analytical Thinking
+- Programming Languages: Sketching Engines
+        </pre>
+      </section>
+    </main>
+
+    <template id="result-template">
+      <article class="result-card">
+        <header class="result-card__header">
+          <h3></h3>
+          <p class="result-card__status"></p>
+        </header>
+        <section class="result-card__body">
+          <h4>LaTeX Output</h4>
+          <textarea class="latex-output" readonly></textarea>
+        </section>
+        <footer class="result-card__footer">
+          <button class="primary-button download-tex" type="button">
+            Download LaTeX
+          </button>
+          <button class="primary-button download-pdf" type="button">
+            Download PDF
+          </button>
+        </footer>
+      </article>
+    </template>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-3nykQeJE72twblwh3yc+yOcoQq32LwNJiyTDON1Om3q9Pymdhx1q2w6kgWSe9SlvEP6zdXIs8KD0w8Lb04E3Jg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add static web app for converting up to five custom-format resumes into LaTeX
- generate downloadable LaTeX and PDF outputs in the browser using jsPDF
- document the workflow and custom resume format in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0cf5d0684832b9a338b296d2ec858