### PR TITLE
Clarify create_leads_sheet docstring

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,10 @@ def _resolve_executor(toolset: ComposioToolSet) -> Callable[[ComposioToolSet, st
 
 
 def create_leads_sheet(leads: List[Dict]) -> str:
-    """Create a Google Sheet with the supplied leads and return its public URL."""
+    """Return the URL for a newly created Google Sheet populated with the supplied leads without changing sharing settings.
+
+    Additional steps are required if the sheet needs to be publicly accessible.
+    """
     api_key = os.getenv("COMPOSIO_API_KEY")
     if not api_key:
         raise ValueError("COMPOSIO_API_KEY environment variable is required to save leads")


### PR DESCRIPTION
## Summary
- clarify the create_leads_sheet docstring to note it returns the new sheet URL without altering sharing settings
- mention that additional steps are necessary to make the sheet publicly accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de18a2fc108331a72b9a58ea42aa22