### PR TITLE
Add static mockup preview and clarify viewing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Hi My name is Saikumar, A expereinced AI Product Manager in various high growth startup scaling 0 to 1 Products from 1k to 300k users across Asia
 Learning Vibe Coding with Codex, V0, Lovable, base44, Cursor, Claude AI
+
+## Portfolio Mockups
+
+### Option 1 · Interactive Next.js preview
+- Install dependencies with `npm install` (first run only).
+- Start the development server using `npm run dev`.
+- Open [`http://localhost:3000/mockups`](http://localhost:3000/mockups) to explore the full interactive wireframes.
+
+### Option 2 · Shareable static snapshot
+- Open [`public/mockups-preview/index.html`](public/mockups-preview/index.html) directly in any modern browser to review a static version of the mockups without running a server.
+- If the repository is hosted on GitHub, you can generate a shareable link with `https://htmlpreview.github.io/?https://github.com/<your-username>/<your-repo>/blob/main/public/mockups-preview/index.html` (replace placeholders accordingly).

--- a/app/mockups/page.tsx
+++ b/app/mockups/page.tsx
@@ -1,0 +1,421 @@
+import Link from "next/link";
+
+const palette = [
+  {
+    name: "Primary",
+    light: "#4057FF",
+    dark: "#8597FF",
+    usage: "Calls-to-action, interactive accents",
+  },
+  {
+    name: "Secondary",
+    light: "#00C39A",
+    dark: "#38E1B8",
+    usage: "Data points, hover states, supporting accents",
+  },
+  {
+    name: "Background",
+    light: "#F5F7FB",
+    dark: "#0E1117",
+    usage: "Page backgrounds, neutral canvases",
+  },
+  {
+    name: "Surface",
+    light: "#FFFFFF",
+    dark: "#141B2C",
+    usage: "Cards, modals, interactive surfaces",
+  },
+  {
+    name: "Typography",
+    light: "#111827",
+    dark: "#E6EDF3",
+    usage: "Headings, body copy, high-contrast text",
+  },
+  {
+    name: "Status",
+    light: "#FFB020 / #FF5D5D",
+    dark: "#FFB020 / #FF5D5D",
+    usage: "Alerts, validation feedback, metrics chips",
+  },
+];
+
+const sections = [
+  {
+    id: "who",
+    title: "Hero · Who I Am",
+    description:
+      "Immersive hero that pairs a personal brand statement with animated identity moments.",
+    highlights: [
+      "Animated role ticker cycling through Product Strategist, AI Experimenter, Team Catalyst.",
+      "Headshot framed by orbiting gradient ring and quick fact overlay on hover.",
+      "Primary CTAs for viewing work and booking a strategy session.",
+    ],
+  },
+  {
+    id: "skills",
+    title: "Skills & Expertise",
+    description:
+      "Tabbed skill system mapping proficiency levels to projects with interactive cards.",
+    highlights: [
+      "Segmented control for Technical, Product, AI/ML, and Soft skills.",
+      "Radial proficiency meters with hover/tap flips for use cases.",
+      "Dynamic project pills surfaced beneath the active tab.",
+    ],
+  },
+  {
+    id: "journey",
+    title: "Professional Journey",
+    description:
+      "Timeline that visualizes 7-year trajectory with expandable achievement drawers.",
+    highlights: [
+      "Desktop horizontal timeline, mobile vertical stacking with sticky year labels.",
+      "Logo monochrome badges that colorize on focus/hover.",
+      "Modal overlays exposing KPIs, team size, and testimonial snippets.",
+    ],
+  },
+  {
+    id: "experiments",
+    title: "AI Experiments Showcase",
+    description:
+      "Filterable gallery highlighting image generation, advanced prompting, and other prototypes.",
+    highlights: [
+      "Masonry grid with category filters and animated tags.",
+      "Before/after sliders and prompt playground micro-app.",
+      "Methodology tabs for context, outcomes, and resources.",
+    ],
+  },
+  {
+    id: "tools",
+    title: "AI Tools & Technologies",
+    description:
+      "Logo-forward grid organized by capability pillars with proficiency overlays.",
+    highlights: [
+      "Carousel behaviour on mobile with swipe gestures.",
+      "Proficiency badges paired with quick win statements.",
+      "Filtering back to related experiments or timeline entries.",
+    ],
+  },
+  {
+    id: "contact",
+    title: "Contact & Collaboration",
+    description:
+      "Conversion-focused contact section featuring multiple outreach paths and validation messaging.",
+    highlights: [
+      "Two-column layout with CTA narrative and accessible form stack.",
+      "Inline validation with success confetti micro-interaction.",
+      "LinkedIn, email, and Calendly quick links surfaced above the fold.",
+    ],
+  },
+];
+
+const Wireframe = ({ id }: { id: string }) => {
+  switch (id) {
+    case "who":
+      return (
+        <div className="relative grid h-72 grid-cols-1 gap-6 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-sky-500 lg:grid-cols-2">
+          <div className="flex flex-col gap-3">
+            <span className="inline-flex w-fit rounded-full bg-sky-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+              Hero Identity
+            </span>
+            <h3 className="text-2xl font-display text-white">Sai Kumar Basole</h3>
+            <p className="max-w-sm text-sm text-slate-300">
+              AI Product Manager with 7+ years orchestrating data-driven products from concept to scalable launch.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {["View My Work", "Book a Strategy Session"].map((cta) => (
+                <span
+                  key={cta}
+                  className="rounded-full bg-sky-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-sky-200"
+                >
+                  {cta}
+                </span>
+              ))}
+            </div>
+            <div className="mt-auto flex items-center gap-2 text-xs text-slate-400">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+              <span>Animated role ticker · Reduced motion safe</span>
+            </div>
+          </div>
+          <div className="relative flex items-center justify-center">
+            <div className="relative flex h-40 w-40 items-center justify-center">
+              <div className="absolute inset-0 animate-spin-slow rounded-full border-4 border-sky-500/60 border-t-transparent" />
+              <div className="absolute inset-2 rounded-full border border-slate-700 bg-slate-950" />
+              <div className="relative h-24 w-24 rounded-full bg-gradient-to-br from-sky-400 via-blue-500 to-indigo-600" />
+            </div>
+            <div className="absolute -bottom-6 right-0 w-40 rounded-xl border border-slate-700 bg-slate-950/80 p-3 text-xs text-slate-300">
+              <p className="font-semibold text-sky-200">Quick Facts</p>
+              <p>7+ yrs experience</p>
+              <p>Responsible AI advocate</p>
+            </div>
+          </div>
+        </div>
+      );
+    case "skills":
+      return (
+        <div className="grid gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-emerald-400">
+          <div className="flex flex-wrap gap-2">
+            {["Technical", "Product", "AI/ML", "Soft Skills"].map((tab, index) => (
+              <span
+                key={tab}
+                className={`rounded-full px-4 py-1 text-xs font-semibold uppercase tracking-wide ${
+                  index === 0 ? "bg-emerald-400/20 text-emerald-200" : "bg-slate-800 text-slate-300"
+                }`}
+              >
+                {tab}
+              </span>
+            ))}
+          </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            {["Prompt Engineering", "Roadmapping", "LLM Orchestration", "Stakeholder Alignment"].map((skill) => (
+              <div key={skill} className="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                <div>
+                  <p className="text-sm font-semibold text-slate-200">{skill}</p>
+                  <p className="text-xs text-slate-400">Advanced · 5 yrs</p>
+                </div>
+                <div className="relative h-14 w-14">
+                  <div className="absolute inset-0 rounded-full border border-slate-700" />
+                  <div className="absolute inset-1 rounded-full border-4 border-emerald-400/80" />
+                  <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-emerald-200">92%</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-dashed border-emerald-400/40 bg-emerald-400/5 p-4 text-xs text-emerald-200">
+            Hover to reveal use cases · Click to filter connected projects
+          </div>
+        </div>
+      );
+    case "journey":
+      return (
+        <div className="grid gap-6 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-sky-400">
+          <div className="relative flex items-center gap-4 overflow-x-auto">
+            {["2024", "2022", "2020", "2018"].map((year, index) => (
+              <div key={year} className="flex min-w-[12rem] flex-col gap-2">
+                <div className="relative flex items-center gap-3">
+                  <div className="relative h-12 w-12 rounded-full border border-slate-700 bg-slate-950">
+                    <span className="absolute inset-1 rounded-full bg-gradient-to-br from-sky-400 to-blue-600" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-slate-200">Role Title</p>
+                    <p className="text-xs text-slate-400">Company · {year} – {index === 0 ? "Present" : `20${index * 2 + 16}`}</p>
+                  </div>
+                </div>
+                <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-3 text-xs text-slate-300">
+                  <p className="font-semibold text-sky-200">Impact</p>
+                  <p>↑ Adoption 35%</p>
+                  <p>Launched 3 AI features</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-xs text-slate-300">
+            Expand nodes for KPIs, testimonials, and tech stack. Mobile defaults to vertical stacking with sticky year chips.
+          </div>
+        </div>
+      );
+    case "experiments":
+      return (
+        <div className="grid gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-purple-400">
+          <div className="flex flex-wrap gap-2">
+            {["All", "Image Generation", "Advanced Prompting", "Other"].map((filter, index) => (
+              <span
+                key={filter}
+                className={`rounded-full px-4 py-1 text-xs font-semibold uppercase tracking-wide ${
+                  index === 0 ? "bg-purple-500/20 text-purple-200" : "bg-slate-800 text-slate-300"
+                }`}
+              >
+                {filter}
+              </span>
+            ))}
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {["Before/After", "Prompt Chains", "Ops Automation"].map((card) => (
+              <div key={card} className="relative h-40 rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-xs text-slate-300">
+                <p className="mb-2 font-semibold text-purple-200">{card}</p>
+                <div className="absolute inset-x-4 bottom-4 flex items-center justify-between text-[10px] text-slate-400">
+                  <span>Outcome</span>
+                  <span>Method</span>
+                </div>
+                <div className="absolute inset-x-4 top-12 h-16 rounded-lg border border-dashed border-purple-400/50" />
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-dashed border-purple-400/50 bg-purple-500/10 p-4 text-xs text-purple-200">
+            Includes interactive prompt tester with pre-computed responses.
+          </div>
+        </div>
+      );
+    case "tools":
+      return (
+        <div className="grid gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-amber-400">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {["OpenAI", "Midjourney", "LangChain", "Pinecone", "Mixpanel", "Figma"].map((tool) => (
+              <div key={tool} className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                <div className="flex items-center justify-between text-xs text-slate-300">
+                  <span className="font-semibold text-amber-200">{tool}</span>
+                  <span className="rounded-full bg-amber-500/20 px-3 py-1 font-semibold text-amber-200">Expert</span>
+                </div>
+                <div className="h-16 rounded-lg border border-dashed border-amber-400/50 bg-amber-400/5" />
+                <p className="text-xs text-slate-400">Used for rapid experimentation and measuring impact.</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-amber-400/40 bg-amber-400/10 p-4 text-xs text-amber-200">
+            Swipe-enabled carousel on mobile with auto-play toggle.
+          </div>
+        </div>
+      );
+    case "contact":
+      return (
+        <div className="grid gap-6 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-inner shadow-slate-950/50 transition hover:border-emerald-300 lg:grid-cols-[1.1fr_1fr]">
+          <div className="flex flex-col gap-4">
+            <p className="text-sm font-semibold uppercase tracking-wide text-emerald-200">Collaboration CTA</p>
+            <h4 className="text-2xl font-display text-white">Let’s build responsible AI experiences together.</h4>
+            <p className="text-sm text-slate-300">
+              Multiple contact pathways supported: email, LinkedIn, and calendar booking. Form integrates spam protection and realtime validation.
+            </p>
+            <div className="flex flex-wrap gap-2 text-xs text-emerald-200">
+              <span className="rounded-full border border-emerald-300/60 px-3 py-1">LinkedIn</span>
+              <span className="rounded-full border border-emerald-300/60 px-3 py-1">Email</span>
+              <span className="rounded-full border border-emerald-300/60 px-3 py-1">Calendly</span>
+            </div>
+          </div>
+          <div className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-xs text-slate-300">
+            <div className="flex flex-col gap-2">
+              <label className="text-[11px] font-semibold uppercase tracking-wide text-emerald-200">Name</label>
+              <div className="h-9 rounded-md border border-slate-700 bg-slate-900" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-[11px] font-semibold uppercase tracking-wide text-emerald-200">Email</label>
+              <div className="h-9 rounded-md border border-slate-700 bg-slate-900" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-[11px] font-semibold uppercase tracking-wide text-emerald-200">Project Type</label>
+              <div className="h-9 rounded-md border border-slate-700 bg-slate-900" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-[11px] font-semibold uppercase tracking-wide text-emerald-200">Message</label>
+              <div className="h-16 rounded-md border border-slate-700 bg-slate-900" />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] text-slate-500">Validation ready · WCAG AA compliant</span>
+              <span className="rounded-full bg-emerald-400/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                Submit
+              </span>
+            </div>
+          </div>
+        </div>
+      );
+    default:
+      return null;
+  }
+};
+
+export default function MockupsPage() {
+  return (
+    <main className="relative mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-16 text-slate-100">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(64,87,255,0.35),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(0,195,154,0.25),_transparent_55%)]" />
+      <header className="space-y-6 text-center">
+        <p className="text-sm uppercase tracking-[0.3em] text-sky-200">Visual Mockups</p>
+        <h1 className="text-4xl font-display text-white md:text-5xl">AI Product Manager Portfolio Experience</h1>
+        <p className="mx-auto max-w-2xl text-base text-slate-300">
+          High-fidelity wireframes and UI direction for a modern, interactive portfolio showcasing Sai Kumar Basole’s AI product leadership. Built for responsive delivery, accessibility, and motion-enhanced storytelling.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3 text-xs text-slate-300">
+          <span className="rounded-full border border-slate-700 px-3 py-1">Responsive · Desktop / Tablet / Mobile</span>
+          <span className="rounded-full border border-slate-700 px-3 py-1">WCAG AA Accessible</span>
+          <span className="rounded-full border border-slate-700 px-3 py-1">Light & Dark Modes</span>
+        </div>
+      </header>
+
+      <section className="grid gap-8 rounded-3xl border border-slate-800/80 bg-slate-950/60 p-8 shadow-xl shadow-slate-950/40">
+        <div className="space-y-4">
+          <h2 className="text-2xl font-display text-white">Visual Language</h2>
+          <p className="max-w-2xl text-sm text-slate-300">
+            The design system pairs confident gradients with high-contrast typography to align with AI innovation while staying recruitment-ready. Provide a mode toggle for instant light/dark transitions with preserved contrast ratios.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-[1.5fr_1fr]">
+          <div className="grid gap-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-200">Color Palette</h3>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {palette.map((swatch) => (
+                <div key={swatch.name} className="flex flex-col gap-2 rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+                  <div className="flex items-center justify-between text-xs text-slate-400">
+                    <span className="font-semibold text-slate-100">{swatch.name}</span>
+                    <span>{swatch.usage}</span>
+                  </div>
+                  <div className="flex h-16 overflow-hidden rounded-xl">
+                    <div className="flex-1" style={{ backgroundColor: swatch.light }} />
+                    <div className="flex-1" style={{ backgroundColor: swatch.dark }} />
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-[10px] text-slate-400">
+                    <span>Light: {swatch.light}</span>
+                    <span>Dark: {swatch.dark}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-6">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-200">Typography</h3>
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Display / H1 · Space Grotesk 700</p>
+              <p className="text-3xl font-display text-white">Design AI experiences that empower people.</p>
+            </div>
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Body · Inter 400</p>
+              <p className="text-sm text-slate-300">
+                Crafted narrative structure with a 4px baseline grid, 70ch line length, and responsive scaling from desktop to mobile. Inputs and code references rely on JetBrains Mono for clarity.
+              </p>
+            </div>
+            <div className="rounded-xl border border-dashed border-sky-400/50 bg-sky-500/10 p-4 text-xs text-sky-100">
+              Include font loading strategies via Next.js with `next/font` to optimize CLS.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-12">
+        {sections.map((section) => (
+          <article key={section.id} className="grid gap-6 rounded-3xl border border-slate-800/80 bg-slate-950/60 p-8 shadow-xl shadow-slate-950/40">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="max-w-xl space-y-2">
+                <h2 className="text-2xl font-display text-white">{section.title}</h2>
+                <p className="text-sm text-slate-300">{section.description}</p>
+              </div>
+              <div className="max-w-md rounded-2xl border border-slate-800 bg-slate-900/70 p-4 text-xs text-slate-300">
+                <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-400">Interaction Notes</p>
+                <ul className="space-y-2">
+                  {section.highlights.map((note) => (
+                    <li key={note} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-400" />
+                      <span>{note}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <Wireframe id={section.id} />
+          </article>
+        ))}
+      </section>
+
+      <footer className="flex flex-col items-center justify-between gap-4 rounded-3xl border border-slate-800/80 bg-slate-950/60 p-8 text-center text-xs text-slate-400 md:flex-row md:text-left">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Implementation Tips</p>
+          <p className="max-w-2xl text-slate-300">
+            Leverage Next.js App Router with Framer Motion for scroll-triggered animations, Tailwind for rapid styling, and Sanity CMS for content agility. Respect prefers-reduced-motion and provide keyboard operability for every interactive element.
+          </p>
+        </div>
+        <Link
+          href="https://www.linkedin.com/in/saikumarbasole"
+          target="_blank"
+          className="rounded-full bg-sky-500 px-4 py-2 font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400"
+        >
+          View LinkedIn Profile
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/public/mockups-preview/index.html
+++ b/public/mockups-preview/index.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Product Manager Portfolio · Mockup Preview</title>
+    <meta
+      name="description"
+      content="Static preview of the AI Product Manager portfolio mockups, including hero, skills, journey, experiments, tools, and contact sections."
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --slate-950: #020617;
+        --slate-900: #0f172a;
+        --slate-800: #1e293b;
+        --slate-200: #e2e8f0;
+        --slate-400: #94a3b8;
+        --slate-500: #64748b;
+        --white: #ffffff;
+        --sky-500: #0ea5e9;
+        --sky-300: #38bdf8;
+        --emerald-400: #34d399;
+        --indigo-500: #6366f1;
+        --background: linear-gradient(160deg, #0e1117 0%, #101522 40%, #1a2235 100%);
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--background);
+        color: var(--slate-200);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 48px 24px 80px;
+        gap: 32px;
+      }
+
+      header {
+        text-align: center;
+        max-width: 960px;
+      }
+
+      header h1 {
+        font-family: "Space Grotesk", "Inter", sans-serif;
+        font-weight: 700;
+        font-size: clamp(2.5rem, 5vw, 3.75rem);
+        margin-bottom: 16px;
+      }
+
+      header p {
+        color: var(--slate-400);
+        margin: 0 auto;
+        font-size: 1.05rem;
+        max-width: 680px;
+      }
+
+      .preview-grid {
+        display: grid;
+        gap: 24px;
+        max-width: 1100px;
+        width: 100%;
+      }
+
+      section {
+        background: rgba(15, 23, 42, 0.7);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 24px;
+        padding: 32px;
+        display: grid;
+        gap: 24px;
+        box-shadow: 0 30px 80px rgba(2, 6, 23, 0.35);
+      }
+
+      section header {
+        text-align: left;
+      }
+
+      section h2 {
+        margin: 0 0 8px;
+        font-family: "Space Grotesk", "Inter", sans-serif;
+        font-size: clamp(1.75rem, 3vw, 2.3rem);
+      }
+
+      section p {
+        margin: 0;
+        color: var(--slate-400);
+        line-height: 1.6;
+      }
+
+      .chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .chip {
+        border-radius: 999px;
+        background: rgba(14, 165, 233, 0.18);
+        padding: 8px 16px;
+        font-size: 0.8rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--sky-300);
+      }
+
+      .two-col {
+        display: grid;
+        gap: 20px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .card {
+        border-radius: 20px;
+        background: rgba(2, 6, 23, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .card h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        color: var(--white);
+      }
+
+      .card p {
+        font-size: 0.95rem;
+        color: var(--slate-400);
+      }
+
+      .highlight {
+        border-radius: 16px;
+        padding: 16px 20px;
+        background: rgba(99, 102, 241, 0.18);
+        border: 1px solid rgba(99, 102, 241, 0.35);
+        font-size: 0.95rem;
+        color: #c7d2fe;
+      }
+
+      .palette-grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .swatch {
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        overflow: hidden;
+      }
+
+      .swatch strong {
+        display: block;
+        padding: 16px 18px 8px;
+        font-size: 0.95rem;
+        letter-spacing: 0.05em;
+      }
+
+      .swatch .tones {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        border-top: 1px solid rgba(148, 163, 184, 0.12);
+      }
+
+      .swatch .tones span {
+        padding: 16px;
+        font-size: 0.85rem;
+        text-align: center;
+      }
+
+      .swatch .usage {
+        padding: 12px 18px 18px;
+        font-size: 0.85rem;
+        color: var(--slate-400);
+      }
+
+      ol, ul {
+        padding-left: 20px;
+        margin: 0;
+        display: grid;
+        gap: 8px;
+      }
+
+      footer {
+        text-align: center;
+        color: var(--slate-500);
+        font-size: 0.85rem;
+        max-width: 720px;
+      }
+
+      footer a {
+        color: var(--sky-300);
+        text-decoration: none;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 32px 16px 64px;
+        }
+
+        section {
+          padding: 24px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>AI Product Manager Portfolio Mockups</h1>
+      <p>
+        This standalone HTML preview mirrors the interactive wireframes built in the Next.js application. Use it to quickly share or
+        review the visual direction for the hero, skills, professional journey, AI experiments, tools, and contact flows without
+        running the development server.
+      </p>
+    </header>
+
+    <div class="preview-grid">
+      <section>
+        <header>
+          <div class="chip">Hero · Who I Am</div>
+          <h2>Immersive identity moment</h2>
+          <p>
+            Split layout hero pairing a personal brand statement with animated role ticker and an orbiting portrait treatment that
+            conveys motion and focus.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Brand Narrative</h3>
+            <p>
+              “AI Product Manager with 7+ years orchestrating data-driven products from concept to scalable launch. Mission: design
+              AI that amplifies human intelligence responsibly.”
+            </p>
+            <div class="highlight">Primary CTAs: View My Work · Book a Strategy Session</div>
+          </div>
+          <div class="card">
+            <h3>Motion Treatment</h3>
+            <p>
+              Circular portrait with gradient ring using the slow-spin accent, paired with hover overlay revealing quick facts such
+              as responsible AI focus and experiment volume.
+            </p>
+            <p class="highlight">Animated ticker cycles titles: Product Strategist → AI Experimenter → Team Catalyst.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">Skills &amp; Expertise</div>
+          <h2>Interactive competency map</h2>
+          <p>
+            Tabbed skill stacks visualise proficiency across technical, product management, AI/ML, and soft skills with radial
+            meters and project filters.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Segmented navigation</h3>
+            <ul>
+              <li>Technical · APIs, SQL, Python, LLM orchestration (5+ years).</li>
+              <li>Product · Vision setting, roadmapping, stakeholder alignment.</li>
+              <li>AI/ML · Prompt engineering, model evaluation, responsible AI.</li>
+              <li>Soft Skills · Cross-functional leadership, storytelling, experimentation culture.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Micro interactions</h3>
+            <p>
+              Cards flip on hover/tap to reveal use cases and link to relevant experiments. Progress arcs animate when scrolled into
+              view.
+            </p>
+            <p class="highlight">Skill tags filter connected experiments surfaced beneath the grid.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">Professional Journey</div>
+          <h2>Seven-year growth timeline</h2>
+          <p>
+            Horizontal timeline (desktop) and stacked milestones (mobile) highlight logos, durations, quantified impact, and
+            testimonials.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Milestone breakdown</h3>
+            <ul>
+              <li>Company nodes expand to reveal KPIs, team size, and strategic wins.</li>
+              <li>Transitions callouts explain role changes and promotion context.</li>
+              <li>Logos start monochrome and glow with brand color on interaction.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Measurement-first storytelling</h3>
+            <p>
+              Achievements spotlight metrics such as +35% model adoption, 3 AI features launched, 0→1 experimentation programs, and
+              user impact counts.
+            </p>
+            <p class="highlight">Expandable drawers use focus traps for keyboard accessibility.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">AI Experiments Showcase</div>
+          <h2>Filterable gallery of prototypes</h2>
+          <p>
+            Masonry grid features image generation, advanced prompting, and supporting tools. Cards open to method, datasets, and
+            outcomes with optional demos.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Gallery highlights</h3>
+            <ul>
+              <li>Before/after sliders for Midjourney and Stable Diffusion image explorations.</li>
+              <li>Prompt playground replicates LLM chains with guardrail notes.</li>
+              <li>Tags show models, latency, and business impact metrics.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Filtering &amp; context</h3>
+            <p>
+              Filters by category and tooling instantly update the layout. Each experiment surfaces methodology, learnings, and next
+              steps for recruiters to assess depth.
+            </p>
+            <p class="highlight">Modal layout supports light/dark mode with accessible contrast ratios.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">AI Tools &amp; Technologies</div>
+          <h2>Capability-aligned tool matrix</h2>
+          <p>
+            Responsive grid or carousel grouping tools by function: Image Generation, NLP, Data Analysis, and Product Operations.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Tool highlights</h3>
+            <ul>
+              <li>OpenAI APIs, LangChain, Pinecone, Midjourney, Stable Diffusion.</li>
+              <li>Analytics and product ops with Mixpanel, Amplitude, Notion, Jira.</li>
+              <li>Design stack via Figma and FigJam with AI-assisted ideation.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Interaction details</h3>
+            <p>
+              Hover reveals proficiency level and signature use case snippet. Clicking filters relevant experiments or timeline
+              moments that prove application depth.
+            </p>
+            <p class="highlight">Supports swipe gestures on mobile for carousel presentation.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">Contact &amp; Collaboration</div>
+          <h2>High-conversion outreach hub</h2>
+          <p>
+            Two-column layout featuring narrative CTA, primary contact form, and instant links to email, LinkedIn, and Calendly.
+          </p>
+        </header>
+        <div class="two-col">
+          <div class="card">
+            <h3>Form structure</h3>
+            <ul>
+              <li>Name, email, project type dropdown, message field, optional budget slider.</li>
+              <li>Inline validation with accessible messaging and ARIA attributes.</li>
+              <li>Success confirmation with subtle confetti micro-interaction.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Supporting channels</h3>
+            <p>
+              Dedicated buttons to email, LinkedIn (<a href="https://www.linkedin.com/in/saikumarbasole/" target="_blank" rel="noreferrer">saikumarbasole</a>),
+              and calendar booking. Mobile responsive with sticky bottom CTA bar.
+            </p>
+            <p class="highlight">Footer captures newsletter opt-in and privacy-friendly analytics notice.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header>
+          <div class="chip">Visual Language</div>
+          <h2>Color palette &amp; typography</h2>
+          <p>
+            Reference the primary UI tokens to maintain consistency across mockups, prototypes, and future production build-outs.
+          </p>
+        </header>
+        <div class="palette-grid">
+          <div class="swatch">
+            <strong>Primary</strong>
+            <div class="tones">
+              <span style="background:#4057FF">#4057FF<br />Light</span>
+              <span style="background:#8597FF">#8597FF<br />Dark</span>
+            </div>
+            <div class="usage">Calls-to-action, animated highlights, navigation focus state.</div>
+          </div>
+          <div class="swatch">
+            <strong>Secondary</strong>
+            <div class="tones">
+              <span style="background:#00C39A">#00C39A<br />Light</span>
+              <span style="background:#38E1B8">#38E1B8<br />Dark</span>
+            </div>
+            <div class="usage">Data visualisations, success messaging, progress arcs.</div>
+          </div>
+          <div class="swatch">
+            <strong>Background</strong>
+            <div class="tones">
+              <span style="background:#F5F7FB; color:#0f172a">#F5F7FB<br />Light</span>
+              <span style="background:#0E1117">#0E1117<br />Dark</span>
+            </div>
+            <div class="usage">Base canvas gradient with subtle particle animation.</div>
+          </div>
+          <div class="swatch">
+            <strong>Surface</strong>
+            <div class="tones">
+              <span style="background:#FFFFFF; color:#0f172a">#FFFFFF<br />Light</span>
+              <span style="background:#141B2C">#141B2C<br />Dark</span>
+            </div>
+            <div class="usage">Cards, modals, drawer surfaces with elevated shadows.</div>
+          </div>
+          <div class="swatch">
+            <strong>Typography</strong>
+            <div class="tones">
+              <span style="background:#111827; color:#e2e8f0">#111827<br />Light</span>
+              <span style="background:#E6EDF3; color:#0f172a">#E6EDF3<br />Dark</span>
+            </div>
+            <div class="usage">Headings in Space Grotesk, body copy in Inter.</div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <footer>
+      <p>
+        Looking for the interactive version? Run <code>npm install</code> followed by <code>npm run dev</code> inside the project and
+        open <a href="http://localhost:3000/mockups" target="_blank" rel="noreferrer">http://localhost:3000/mockups</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,9 @@ module.exports = {
       fontFamily: {
         display: ['"DM Sans"', 'sans-serif'],
         body: ['"Inter"', 'sans-serif']
+      },
+      animation: {
+        'spin-slow': 'spin 6s linear infinite'
       }
     },
   },


### PR DESCRIPTION
## Summary
- document both interactive and static ways to preview the portfolio mockups in the README
- add a standalone HTML snapshot of the mockups under public/mockups-preview for quick sharing without running Next.js

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f29016c9448331b88f6b6ddec599cb